### PR TITLE
Remove page jumping when images are not yet loaded fixing Xon/XenForo…

### DIFF
--- a/addon-SV_LazyImageLoader.xml
+++ b/addon-SV_LazyImageLoader.xml
@@ -58,7 +58,7 @@
     </modification>
     <modification template="bb_code_tag_attach" modification_key="sv_lazyimageloader_bb_code_tag_attach" description="Lazy Image Loader" execution_order="10" enabled="1" action="preg_replace">
       <find><![CDATA[#(<img\s+src=")([^"]*)(".*?class="[^"]*)("\s*?/>)#is]]></find>
-      <replace><![CDATA[$1<xen:callback class='SV_LazyImageLoader_Helper' method='getLazySpinnerUrl' params='$2' />$3 <xen:callback class='SV_LazyImageLoader_Helper' method='getLazySpinnerCss' params='{xen:array 'full={$full}', 'attachment={$attachment}', 'extra=$4', 'noscript={$1$2$3$4}'}' />]]></replace>
+      <replace><![CDATA[$1<xen:callback class='SV_LazyImageLoader_Helper' method='getLazySpinnerUrl' params='{xen:array 'url=$2', 'width={$attachment.width}', 'height={$attachment.height}'}' />$3 <xen:callback class='SV_LazyImageLoader_Helper' method='getLazySpinnerCss' params='{xen:array 'full={$full}', 'attachment={$attachment}', 'extra=$4', 'noscript={$1$2$3$4}'}' />]]></replace>
     </modification>
     <modification template="bb_code.css" modification_key="sv_lazyimageloader_bb_codecss_1" description="Add NoJs support" execution_order="10" enabled="1" action="preg_replace">
       <find><![CDATA[#$#]]></find>

--- a/upload/library/SV/LazyImageLoader/Helper.php
+++ b/upload/library/SV/LazyImageLoader/Helper.php
@@ -27,12 +27,21 @@ class SV_LazyImageLoader_Helper
 
     public static function getLazySpinnerUrl($content, $params, XenForo_Template_Abstract $template)
     {
+        $originalUrl = is_array($params) ? $params['url'] : $params;
         if (SV_LazyImageLoader_Helper::$enable_lazyloading)
         {
-            return  '" data-src="' . $params;
+            $placeholder = '';
+            if (is_array($params))
+            {
+                $width = $params['width'];
+                $height = $params['height'];
+                $placeholder = "data:image/svg+xml;charset=utf-8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 {$width} {$height}'%2F%3E";
+            }
+            // Insert an SVG with proper aspect ratio to make responsive design work smoothly
+            return $placeholder . '" data-src="' . $originalUrl;
         }
 
-        return $params;
+        return $originalUrl;
     }
 
     static $enable_lazyloading = null;


### PR DESCRIPTION
I altered the way images are presented from src="" to src="an SVG with the canvas dimensions of the attachment image" which means they work with responsive "max-width: 100%" and all that. Works great for me.

Please make sure it does not break non-attachment images. It shouldn't, but I was unable to test it because I don't have all the same addons as you.